### PR TITLE
Fixes bug where resolving a LinkItem doesn't respect options.

### DIFF
--- a/LinkResolverService.cs
+++ b/LinkResolverService.cs
@@ -39,7 +39,7 @@ namespace Blend.Optimizely
 
         public virtual ResolvedLink? ResolveLinkItem(LinkItem linkItem, LinkOptions options = LinkOptions.None)
         {
-            var resolvedUrl = ResolveUrlString(linkItem.Href);
+            var resolvedUrl = ResolveUrlString(linkItem.Href, options);
             if (resolvedUrl is null)
                 return null;
 


### PR DESCRIPTION
When resolving a LinkItem with `LinkOptions.IncludeDomain`, the full URL with domain was not being returned. This fixes that.