### PR TITLE
Call the appropriate HasValue() for each type

### DIFF
--- a/src/Blend.Optimizely/HasValueExtensions.cs
+++ b/src/Blend.Optimizely/HasValueExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using EPiServer;
 using EPiServer.Core;
 using EPiServer.SpecializedProperties;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -27,6 +28,19 @@ namespace Blend.Optimizely
         public static bool HasValue<T>([NotNullWhen(true)] this IEnumerable<T>? array) => array != null && array.Any();
 
         public static bool HasValue([NotNullWhen(true)] this LinkItem? item) => item != null && item.Text.HasValue() && item.Href.HasValue();
+
+        public static bool HasValue([NotNullWhen(true)] this object? value) => value switch
+        {
+            ContentReference contentReference => contentReference.HasValue(),
+            ContentArea contentArea => contentArea.HasValue(),
+            XhtmlString xhtmlString => xhtmlString.HasValue(),
+            string stringValue => stringValue.HasValue(),
+            Url url => url.HasValue(),
+            LinkItemCollection linkItemCollection => linkItemCollection.HasValue(),
+            IEnumerable iEnumerable => iEnumerable.HasValue(),
+            LinkItem linkItem => linkItem.HasValue(),
+            _ => value != null
+        };
 
         public static ContentReference Coalesce(this ContentReference? value, ContentReference alternative) => value.HasValue() ? value : alternative;
 

--- a/src/Blend.Optimizely/HtmlExtensions.cs
+++ b/src/Blend.Optimizely/HtmlExtensions.cs
@@ -53,8 +53,6 @@ namespace Blend.Optimizely
         {
             ModelExpression modelExpression = html.ViewContext.HttpContext.RequestServices.GetRequiredService<ModelExpressionProvider>().CreateModelExpression(html.ViewData, expression);
 
-            var hasValue = modelExpression.Model != null;
-
             var displayFor = html.DisplayFor(expression);
 
             var contextModeResolver = ServiceLocator.Current.GetInstance<IContextModeResolver>();
@@ -66,7 +64,7 @@ namespace Blend.Optimizely
             }
 
             // view mode with value
-            if (hasValue)
+            if (modelExpression.Model.HasValue())
             {
                 return RenderPropertyForViewMode(htmlTagName, innerHtmlTagName, htmlAttributes, displayFor);
             }


### PR DESCRIPTION
Add a `HasValue()` extension method for `object` and update the `PropertyTemplateFor()` extension method to not render elements if the value is null.